### PR TITLE
Add zod as explicit dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@msfeldstein/mcp-test-servers",
-  "version": "1.1.70",
+  "version": "1.1.71",
   "type": "module",
   "bin": {
     "mcp-test-servers": "./src/cli.js"
@@ -23,7 +23,8 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.17.0",
     "cors": "^2.8.5",
-    "express": "^4.21.2"
+    "express": "^4.21.2",
+    "zod": "^3.25.76"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
zod is required by @modelcontextprotocol/sdk but isn't listed as a direct dependency. This causes failures when using bazel to run tests, as bazel requires all transitive dependencies to be explicitly declared.

Using version ^3.25.76 from package-lock.json.