### PR TITLE
chore: ping-server import spacing (PR flow test)

### DIFF
--- a/src/ping-server.js
+++ b/src/ping-server.js
@@ -3,6 +3,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
+
 // Create a new MCP server with stdio transport
 const server = new McpServer(
   {


### PR DESCRIPTION
Small whitespace-only change after the import block in `ping-server.js` to verify the branch → push → PR workflow.

**Testing:** Not applicable (no behavior change).